### PR TITLE
Functional Options: Create a relative package, set the link

### DIFF
--- a/idiom/functional-options.md
+++ b/idiom/functional-options.md
@@ -93,8 +93,9 @@ if err != nil {
 }
 ```
 
-## Packages
+## Relative
 
-Packages helps you understand how this pattern works:
+Relative links and source codeview that helps you understand how this pattern works and  can be extended to fit your needs:
 
 - [go-options](https://github.com/kataras/go-options)
+- [configuration.go:26](https://github.com/kataras/iris/blob/master/configuration.go#L26), [configuration.go:160](https://github.com/kataras/iris/blob/master/configuration.go#L160), [iris.go:202](https://github.com/kataras/iris/blob/master/iris.go#L202)

--- a/idiom/functional-options.md
+++ b/idiom/functional-options.md
@@ -92,3 +92,9 @@ if err != nil {
     panic(err)
 }
 ```
+
+## Packages
+
+Packages helps you understand how this pattern works:
+
+- [go-options](https://github.com/kataras/go-options)

--- a/idiom/functional-options.md
+++ b/idiom/functional-options.md
@@ -98,4 +98,4 @@ if err != nil {
 Relative links and source codeview that helps you understand how this pattern works and  can be extended to fit your needs:
 
 - [go-options](https://github.com/kataras/go-options)
-- [configuration.go:26](https://github.com/kataras/iris/blob/master/configuration.go#L26), [configuration.go:160](https://github.com/kataras/iris/blob/master/configuration.go#L160), [iris.go:202](https://github.com/kataras/iris/blob/master/iris.go#L202)
+- A web framework's flow: [configuration.go:26](https://github.com/kataras/iris/blob/master/configuration.go#L26), [configuration.go:160](https://github.com/kataras/iris/blob/master/configuration.go#L160), [iris.go:202](https://github.com/kataras/iris/blob/master/iris.go#L202), [iris.go:259](https://github.com/kataras/iris/blob/master/iris.go#L259)


### PR DESCRIPTION
Hi @tmrts, First of all I don't want this to act like 'advertisement' ( I personally don't like 'advertisements' in github), if it's acted like that then do not approve this PR.

I made a package only to help readers of this go-patterns repository to understand how they can extend `Pattern: Functional Options` to fit to their needs, so I added a section with relative links of this particular pattern. I could also recommend search and do the same for other patterns, it's good to add relative links  in order to see how they(readers) can extend a pattern, it will help to understand better the subject, I hope.