### PR TITLE
Result is not defined

### DIFF
--- a/concurrency/generator.md
+++ b/concurrency/generator.md
@@ -11,7 +11,7 @@ func Count(start int, end int) chan int {
     go func(ch chan int) {
         for i := start; i < end ; i++ {
             // Blocks on the operation
-            ch <- result
+            ch <- i
         }
 
 		close(ch)


### PR DESCRIPTION
The example is not working because `result` is not defined.
Now the example works