### PR TITLE
structural/proxy: fix typo for word handle

### DIFF
--- a/structural/proxy.md
+++ b/structural/proxy.md
@@ -18,7 +18,7 @@ Short idea of implementation:
         action string
     }
 
-    // ObjDo implements IObject interface and handel's all logic
+    // ObjDo implements IObject interface and handles all logic
     func (obj *Object) ObjDo(action string) {
         // Action behavior
         fmt.Printf("I can, %s", action)


### PR DESCRIPTION
Fix typo for the word handle