### PR TITLE
fix some error in file object-pool.md

### DIFF
--- a/creational/object-pool.md
+++ b/creational/object-pool.md
@@ -29,10 +29,10 @@ Given below is a simple lifecycle example on an object pool.
 p := pool.New(2)
 
 select {
-case obj := <-p:
+case obj := <-*p:
 	obj.Do( /*...*/ )
 
-	p <- obj
+	*p <- obj
 default:
 	// No more objects left — retry later or fail
 	return


### PR DESCRIPTION
Because the type of p at line 29 is"*chan *Object" , so at line 32, 35 should use *p instead of p directly.